### PR TITLE
Same endpoint for feedback and suggestions

### DIFF
--- a/client/src/components/add-word-fieldset/add-word-fieldset.html
+++ b/client/src/components/add-word-fieldset/add-word-fieldset.html
@@ -1,46 +1,68 @@
 <div [formGroup]="formGroup">
-  <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
-                  [hintLabel]="'e.g. هتاف للترحيب' | translate:'nativeScriptHint'">
-    <mat-label [innerHTML]="'Word in native script' | translate:'wordInNativeScript'"></mat-label>
-    <input type="text" matInput name="nativeWord" formControlName="nativeWord" maxlength="100" />
-    <mat-error *ngIf="fieldHasError('nativeWord', 'required')" [innerHTML]="'Word in native script is required' | translate:'nativeWordRequired'"></mat-error>
-  </mat-form-field>
-  <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
-                  [hintLabel]="'e.g. \'hello\'' | translate:'englishWordHint'">
-    <mat-label [innerHTML]="'Word in English' | translate:'wordInEnglish'"></mat-label>
-    <input type="text" matInput name="englishWord" formControlName="englishWord" maxlength="100" />
-    <mat-error *ngIf="fieldHasError('englishWord', 'required')" [innerHTML]="'English word is required' | translate:'englishWordRequired'"></mat-error>
-  </mat-form-field>
-  <mat-form-field *ngIf="primaryLanguageWordAvailable" class="text" appearance="outline" [hideRequiredMarker]="true"
-                  [hintLabel]="'e.g. \'hello\'' | translate:'wordInPrimaryLanguageHint'">
-    <mat-label [innerHTML]="'Word in English' | translate:'wordInPrimaryLanguage'"></mat-label>
-    <input type="text" matInput name="word" formControlName="word" maxlength="100" />
-    <mat-error *ngIf="fieldHasError('word', 'required')" [innerHTML]="'English word is required' | translate:'wordInPrimaryLanguageRequired'"></mat-error>
-  </mat-form-field>
-  <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
-                  [hintLabel]="'Word in Latin alphabet (e.g. \'marhaba\')' | translate:'transliterationHint'">
-    <mat-label [innerHTML]="'Transliteration (optional)' | translate:'transliteration'"></mat-label>
-    <input type="text" matInput name="transliteration" formControlName="transliteration" />
-  </mat-form-field>
-  <div class="record" *ngIf="audioRecordingIsAvailable">
-    <label class="mat-body-1" [innerHTML]="'Record pronunciation' | translate:'recordPronunciation'"></label>
-    <button class="start" *ngIf="recordingState === recordingStateValues.Idle
-          || recordingState === recordingStateValues.Finished" (click)="onStartRecordingClick($event)">
-      <app-icon icon="record_audio" color="primary"></app-icon></button>
-    <button class="stop" *ngIf="recordingState === recordingStateValues.Recording
-          || recordingState === recordingStateValues.Playing" (click)="onStopRecordingClick($event)">
-      <app-icon icon="stop_audio" color="primary"></app-icon>
-      <app-progress-border [borderWidth]="2.5" [progress]="audioStreamProgress"></app-progress-border>
-    </button>
-    <span class="play-container" *ngIf="recordingState === recordingStateValues.Finished">
-      <button class="play" (click)="onPlayRecordingClick($event)">
-        <app-icon icon="play_recording" color="primary"></app-icon>
-      </button>
-      <span [innerHTML]="'Saved' | translate:'saved'"></span>
-    </span>
-  </div>
-  <div class="special-chars">
-    <span *ngIf="operatingSystem === operatingSystemValues.Android || operatingSystem === operatingSystemValues.iOS"
-          [innerHTML]="'Want to type special characters? Try <a href=\'${gboardUrl}\'>GBoard</a> or <a href=\'${keymanUrl}\'>Keyman</a>' | translate:'specialCharsInstructions'"></span>
+  <div style="display: flex; flex-direction: column;">
+    <div style="display: flex; flex-direction: column;" *ngIf="!suggested">
+      <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true">
+        <mat-label [innerHTML]="'Current Word in native script' | translate:'wordInNativeScript'"></mat-label>
+        <input type="text" matInput name="nativeWord" formControlName="nativeWord" maxlength="100" />
+        <mat-error *ngIf="fieldHasError('nativeWord', 'required')" [innerHTML]="'Word in native script is required' | translate:'nativeWordRequired'"></mat-error>
+      </mat-form-field>
+      <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true">
+        <mat-label [innerHTML]="'Current Transliteration'"></mat-label>
+      <input type="text" matInput name="transliteration" formControlName="transliteration" />
+      </mat-form-field>
+      <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
+        [hintLabel]="'e.g. هتاف للترحيب' | translate:'nativeScriptHint'">
+      <mat-label [innerHTML]="'Suggested Word in native script (optional)'"></mat-label>
+      <input type="text" matInput name="suggestedTranslation" formControlName="suggestedTranslation" maxlength="100" />
+      </mat-form-field>
+    </div>
+    <div style="display: flex; flex-direction: column;" *ngIf="suggested">
+      <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
+        [hintLabel]="'e.g. هتاف للترحيب' | translate:'nativeScriptHint'">
+      <mat-label [innerHTML]="'Suggested Word in native script'"></mat-label>
+      <input type="text" matInput name="suggestedTranslation" formControlName="suggestedTranslation" maxlength="100" />
+      <mat-error *ngIf="fieldHasError('suggestedTranslation', 'required')" [innerHTML]="'Suggested word is required' | translate:'suggestedTranslationRequird'"></mat-error>
+      </mat-form-field>
+    </div>
+    <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
+    [hintLabel]="'Word in Latin alphabet (e.g. \'marhaba\')' | translate:'transliterationHint'">
+      <mat-label [innerHTML]="'Suggested Transliteration (optional)'"></mat-label>
+      <input type="text" matInput name="suggestedTransliteration" formControlName="suggestedTransliteration" />
+      </mat-form-field>
+    <mat-form-field class="text" appearance="outline" [hideRequiredMarker]="true"
+                    [hintLabel]="'e.g. \'hello\'' | translate:'englishWordHint'">
+      <mat-label [innerHTML]="'Word in English' | translate:'wordInEnglish'"></mat-label>
+      <input type="text" matInput name="englishWord" formControlName="englishWord" maxlength="100" />
+      <mat-error *ngIf="fieldHasError('englishWord', 'required')" [innerHTML]="'English word is required' | translate:'englishWordRequired'"></mat-error>
+    </mat-form-field>
+    <mat-form-field *ngIf="primaryLanguageWordAvailable" class="text" appearance="outline" [hideRequiredMarker]="true"
+                    [hintLabel]="'e.g. \'hello\'' | translate:'wordInPrimaryLanguageHint'">
+      <mat-label [innerHTML]="'Word in English' | translate:'wordInPrimaryLanguage'"></mat-label>
+      <input type="text" matInput name="word" formControlName="word" maxlength="100" />
+      <mat-error *ngIf="fieldHasError('word', 'required')" [innerHTML]="'English word is required' | translate:'wordInPrimaryLanguageRequired'"></mat-error>
+    </mat-form-field>
+    <div *ngIf="includeRecording">
+      <div class="record" *ngIf="audioRecordingIsAvailable">
+        <label class="mat-body-1" [innerHTML]="'Record pronunciation' | translate:'recordPronunciation'"></label>
+        <button class="start" *ngIf="recordingState === recordingStateValues.Idle
+              || recordingState === recordingStateValues.Finished" (click)="onStartRecordingClick($event)">
+          <app-icon icon="record_audio" color="primary"></app-icon></button>
+        <button class="stop" *ngIf="recordingState === recordingStateValues.Recording
+              || recordingState === recordingStateValues.Playing" (click)="onStopRecordingClick($event)">
+          <app-icon icon="stop_audio" color="primary"></app-icon>
+          <app-progress-border [borderWidth]="2.5" [progress]="audioStreamProgress"></app-progress-border>
+        </button>
+        <span class="play-container" *ngIf="recordingState === recordingStateValues.Finished">
+          <button class="play" (click)="onPlayRecordingClick($event)">
+            <app-icon icon="play_recording" color="primary"></app-icon>
+          </button>
+          <span [innerHTML]="'Saved' | translate:'saved'"></span>
+        </span>
+      </div>
+    </div>
+    <div class="special-chars">
+      <span *ngIf="operatingSystem === operatingSystemValues.Android || operatingSystem === operatingSystemValues.iOS"
+            [innerHTML]="'Want to type special characters? Try <a href=\'${gboardUrl}\'>GBoard</a> or <a href=\'${keymanUrl}\'>Keyman</a>' | translate:'specialCharsInstructions'"></span>
+    </div>
   </div>
 </div>

--- a/client/src/components/add-word-fieldset/add-word-fieldset.ts
+++ b/client/src/components/add-word-fieldset/add-word-fieldset.ts
@@ -50,9 +50,9 @@ export class AddWordFieldsetComponent {
   // only show primary language word if current language is not english
   public get primaryLanguageWordAvailable(): boolean { return this.i18n.currentLanguage.code != DEFAULT_LOCALE; }
 
-  @Input()
-  public formGroup: FormGroup | undefined = undefined;
-
+  @Input() public formGroup: FormGroup | undefined = undefined;
+  @Input() public includeRecording: boolean = true;
+  @Input() public suggested: boolean = true;
   constructor(
     @Inject(ADD_WORD_FIELDSET_CONFIG) private config: AddWordFieldsetConfig,
     private zone: NgZone,

--- a/client/src/components/translation-selector/translation-selector.html
+++ b/client/src/components/translation-selector/translation-selector.html
@@ -24,11 +24,10 @@
   <audio #audioPlayer [src]="selectedWord.soundURL | gcsUrl" preload="none" (play)="onAudioPlaying()"
     (ended)="onAudioStopped()" (pause)="onAudioStopped()"></audio>
 </div>
-<div class="translation-not-found" [class.hidden]="!selectedWordVisible"
-  *ngIf="selectedWord && !selectedWord.translation">
+<div class="add-word" [class.hidden]="!selectedWordVisible">
   <div class="message" (click)="onAddTranslationClick()">
     <app-icon icon="add" shadow="true"></app-icon>
-    <span [innerHTML]="'Add word' | translate:'addWord'"></span>
+    <span [innerHTML]="'Add word' | translate:'sendFeedback'"></span>
   </div>
 </div>
 <app-selection-line [class.hidden]="!selectedWordVisible" [targetPosition]="lineTargetPosition"></app-selection-line>

--- a/client/src/components/translation-selector/translation-selector.html
+++ b/client/src/components/translation-selector/translation-selector.html
@@ -25,7 +25,7 @@
     (ended)="onAudioStopped()" (pause)="onAudioStopped()"></audio>
 </div>
 <div class="add-word" [class.hidden]="!selectedWordVisible">
-  <div class="message" (click)="onAddTranslationClick()">
+  <div class="message" (click)="onAddTranslationClick()" (keydown)="onKeyDown($event)">
     <app-icon icon="add" shadow="true"></app-icon>
     <span [innerHTML]="'Add word' | translate:'sendFeedback'"></span>
   </div>

--- a/client/src/components/translation-selector/translation-selector.scss
+++ b/client/src/components/translation-selector/translation-selector.scss
@@ -98,7 +98,7 @@
   }
 }
 
-.translation-not-found {
+.add-word {
   flex: 0 0 auto;
   color: mat.get-color-from-palette($app-inverted, '500-contrast');
   text-align: center;
@@ -107,7 +107,7 @@
 
   .message {
     margin-bottom: 20px;
-    font-size: 3rem;
+    font-size: 2rem;
     line-height: 3rem;
     cursor: pointer;
 
@@ -140,7 +140,7 @@ app-selection-line {
 }
 
 .translation-container,
-.translation-not-found,
+.add-word,
 app-selection-line {
   transition: opacity 0.3s ease-in-out;
 

--- a/client/src/components/translation-selector/translation-selector.ts
+++ b/client/src/components/translation-selector/translation-selector.ts
@@ -43,6 +43,12 @@ export class TranslationSelectorComponent {
 
   constructor() {
   }
+  onKeyDown(event: KeyboardEvent): void {
+    console.log('Key pressed:', event.key);
+    if (event.key === 'Enter') {
+      this.onAddTranslationClick();
+    }
+  }    
 
   onPlayAudioClick() {
     if (!this.audioPlayer || !this.audioPlayer.nativeElement) {

--- a/client/src/components/translation-selector/translation-selector.ts
+++ b/client/src/components/translation-selector/translation-selector.ts
@@ -44,7 +44,6 @@ export class TranslationSelectorComponent {
   constructor() {
   }
   onKeyDown(event: KeyboardEvent): void {
-    console.log('Key pressed:', event.key);
     if (event.key === 'Enter') {
       this.onAddTranslationClick();
     }

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -403,8 +403,7 @@ export const environment = {
       type: APIFeedbackService,
       config: {
         addWordAudioEndpointURL: `${params.apiUrl}/saveAudioSuggestions`,
-        addWordEndpointURL: `${params.apiUrl}/addSuggestions`,
-        feedbackEndpointURL: `${params.apiUrl}/addFeedback`
+        feedbackEndpointURL: `${params.apiUrl}/create_feedback/`
       }
     }
   }

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -403,7 +403,7 @@ export const environment = {
       type: APIFeedbackService,
       config: {
         addWordAudioEndpointURL: `${params.apiUrl}/saveAudioSuggestions`,
-        feedbackEndpointURL: `${params.apiUrl}/create_feedback/`
+        feedbackEndpointURL: `https://cilex-woolaroo-2.uc.r.appspot.com/create_feedback/`,
       }
     }
   }

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -460,7 +460,7 @@ export const environment = {
 			type: APIFeedbackService,
 			config: {
 				addWordAudioEndpointURL: `${baseEndpointUrl}/saveAudioSuggestions`,
-				feedbackEndpointURL: `${baseEndpointUrl}/create_feedback/`,
+				feedbackEndpointURL: `https://cilex-woolaroo-2.uc.r.appspot.com/create_feedback/`,
 			},
 		},
 	},

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -460,8 +460,7 @@ export const environment = {
 			type: APIFeedbackService,
 			config: {
 				addWordAudioEndpointURL: `${baseEndpointUrl}/saveAudioSuggestions`,
-				addWordEndpointURL: `${baseEndpointUrl}/addSuggestions`,
-				feedbackEndpointURL: `${baseEndpointUrl}/addFeedback`,
+				feedbackEndpointURL: `${baseEndpointUrl}/create_feedback/`,
 			},
 		},
 	},

--- a/client/src/pages/add-word/add-word.html
+++ b/client/src/pages/add-word/add-word.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" (ngSubmit)="onFormSubmit()">
   <mat-toolbar>
     <button class="close" (click)="onCloseClick($event)"><app-icon icon="close"></app-icon></button>
-    <span [innerHTML]="'Add word' | translate: 'addWord'">Add word</span>
+    <span [innerHTML]="'Add word' | translate: 'sendFeedback'">Add word</span>
     <button mat-button color="primary" class="submit" type="submit">
       <span [innerHTML]="'Add' | translate: 'add'"></span>
     </button>

--- a/client/src/pages/add-word/add-word.ts
+++ b/client/src/pages/add-word/add-word.ts
@@ -13,7 +13,7 @@ import { environment } from '../../environments/environment';
 import { DEFAULT_LOCALE } from '../../util/locale';
 import { I18nService } from '../../i18n/i18n.service';
 import { EndangeredLanguageService } from '../../services/endangered-language';
-import { AddedWord } from '../../services/entities/feedback';
+import { Feedback } from '../../services/entities/feedback';
 import { getLogger } from '../../util/logging';
 
 const logger = getLogger('AddWordPageComponent');
@@ -52,8 +52,15 @@ export class AddWordPageComponent implements AfterViewInit {
       ]),
       transliteration: new FormControl(word ? word.transliteration : '', [
       ]),
+      suggestedTranslation: new FormControl(null, [
+      ]),
+      suggestedTransliteration: new FormControl(null, [
+      ]),
       recording: new FormControl(null, [
       ]),
+      types: new FormControl(['suggested'], [
+        (ctl) => ctl.dirty && (!ctl.value || ctl.value.length === 0) ? { required: true } : null
+      ])
     });
     this.prevPageCssClass = history.state.prevPageCssClass;
   }
@@ -72,13 +79,13 @@ export class AddWordPageComponent implements AfterViewInit {
     }
     this.submittingForm = true;
     const loadingPopup = this.dialog.open(LoadingPopUpComponent, { panelClass: 'loading-popup' });
-    const addedWord: AddedWord = this.form.value;
-    if (!addedWord.word && this.i18n.currentLanguage.code == DEFAULT_LOCALE) {
-      addedWord.word = addedWord.englishWord;
+    const feedback: Feedback = this.form.value;
+    if (!feedback.word && this.i18n.currentLanguage.code == DEFAULT_LOCALE) {
+      feedback.word = feedback.englishWord;
     }
-    addedWord.language = this.i18n.currentLanguage.code;
-    addedWord.nativeLanguage = this.endangeredLanguageService.currentLanguage.code;
-    this.feedbackService.addWord(this.form.value).then(
+    feedback.language = this.i18n.currentLanguage.code;
+    feedback.nativeLanguage = this.endangeredLanguageService.currentLanguage.code;
+    this.feedbackService.sendFeedback(this.form.value).then(
       () => {
         logger.log('Added word submitted');
         this.location.back();
@@ -92,7 +99,7 @@ export class AddWordPageComponent implements AfterViewInit {
       },
       err => {
         logger.warn('Failed adding word', err);
-        const errorMessage = this.i18n.getTranslation('addWordError') || 'Unable to add word';
+        const errorMessage = this.i18n.getTranslation('sendFeedbackError') || 'Unable to add word';
         this.dialog.open(ErrorPopUpComponent, { data: { message: errorMessage } });
       }
     ).finally(

--- a/client/src/pages/feedback/feedback.html
+++ b/client/src/pages/feedback/feedback.html
@@ -25,8 +25,8 @@
       </ul>
       <mat-error *ngIf="feedbackForm.controls['types'].hasError('required')" [innerHTML]="'No feedback type selected' | translate:'feedbackTypeRequired'"></mat-error>
     </div>
-    <app-add-word-fieldset [formGroup]="feedbackForm"></app-add-word-fieldset>
-    <mat-form-field class="textarea" appearance="outline">
+    <app-add-word-fieldset [formGroup]="feedbackForm" [includeRecording]="false" [suggested]="false"></app-add-word-fieldset>
+    <mat-form-field class="textarea" appearance="outline" style="display: block;">
       <mat-label [innerHTML]="'Enter feedback' | translate:'enterFeedback'"></mat-label>
       <textarea matInput name="content" required formControlName="content"></textarea>
       <mat-error *ngIf="feedbackForm.controls['content'].hasError('required')" [innerHTML]="'Feedback required' | translate:'feedbackRequired'"></mat-error>

--- a/client/src/pages/feedback/feedback.ts
+++ b/client/src/pages/feedback/feedback.ts
@@ -43,6 +43,10 @@ export class FeedbackPageComponent implements AfterViewInit {
       nativeWord: new FormControl(word ? word.translation : '', []),
       englishWord: new FormControl(word ? word.english : '', []),
       transliteration: new FormControl(word ? word.transliteration : '', []),
+      suggestedTranslation: new FormControl(null, [
+      ]),
+      suggestedTransliteration: new FormControl(null, [
+      ]),
       recording: new FormControl(null, []),
       content: new FormControl('', [
         Validators.required

--- a/client/src/services/api/feedback.ts
+++ b/client/src/services/api/feedback.ts
@@ -36,7 +36,7 @@ export class APIFeedbackService implements IFeedbackService {
       native_language: feedback.nativeLanguage,
       sound_link: soundUrl,
       types: feedback.types,
-      content: feedback.content
+      content: feedback.content || ''
     };
     await this.http.post(this.config.feedbackEndpointURL, requestBody, { responseType: 'text' }).toPromise();
     logger.log('Feedback sent');

--- a/client/src/services/api/feedback.ts
+++ b/client/src/services/api/feedback.ts
@@ -1,12 +1,11 @@
 import { Inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { IFeedbackService, FEEDBACK_CONFIG } from 'services/feedback';
-import { AddedWord, Feedback } from 'services/entities/feedback';
-import {getLogger} from 'util/logging';
+import { Feedback } from 'services/entities/feedback';
+import { getLogger } from 'util/logging';
 
 interface APIFeedbackConfig {
   addWordAudioEndpointURL: string;
-  addWordEndpointURL: string;
   feedbackEndpointURL: string;
 }
 
@@ -30,34 +29,16 @@ export class APIFeedbackService implements IFeedbackService {
       primary_word: feedback.word ? feedback.word.toLowerCase() : feedback.word,
       english_word: feedback.englishWord ? feedback.englishWord.toLowerCase() : feedback.englishWord,
       translation: feedback.nativeWord ? feedback.nativeWord.toLowerCase() : feedback.nativeWord,
+      transliteration: feedback.transliteration ? feedback.transliteration.toLowerCase() : feedback.transliteration,
+      suggested_translation: feedback.suggestedTranslation ? feedback.suggestedTranslation.toLowerCase() : feedback.suggestedTranslation,
+      suggested_transliteration: feedback.suggestedTransliteration ? feedback.suggestedTransliteration.toLowerCase() : feedback.suggestedTransliteration,
       language: feedback.language,
       native_language: feedback.nativeLanguage,
-      transliteration: feedback.transliteration ? feedback.transliteration.toLowerCase() : feedback.transliteration,
       sound_link: soundUrl,
       types: feedback.types,
       content: feedback.content
     };
     await this.http.post(this.config.feedbackEndpointURL, requestBody, { responseType: 'text' }).toPromise();
     logger.log('Feedback sent');
-  }
-
-  public async addWord(word: AddedWord): Promise<any> {
-    let soundUrl: string|null = null;
-    if (word.recording) {
-      logger.log('Sending audio');
-      soundUrl = await this.http.post(this.config.addWordAudioEndpointURL, word.recording, { responseType: 'text' }).toPromise();
-    }
-    logger.log('Adding word');
-    const requestBody = {
-      primary_word: word.word ? word.word.toLowerCase() : word.word,
-      english_word: word.englishWord ? word.englishWord.toLowerCase() : word.englishWord,
-      translation: word.nativeWord ? word.nativeWord.toLowerCase() : word.nativeWord,
-      transliteration: word.transliteration ? word.transliteration.toLowerCase() : word.transliteration,
-      language: word.language,
-      native_language: word.nativeLanguage,
-      sound_link: soundUrl
-    };
-    await this.http.post(this.config.addWordEndpointURL, requestBody, { responseType: 'text' }).toPromise();
-    logger.log('Word added');
   }
 }

--- a/client/src/services/entities/feedback.ts
+++ b/client/src/services/entities/feedback.ts
@@ -1,11 +1,10 @@
 export enum FeedbackType {
-  IncorrectTranslation = 'IncorrectTranslation',
-  OffensiveTranslation = 'OffensiveTranslation',
-  AlternateTranslation = 'AlternateTranslation',
-  Other = 'Other'
+  IncorrectTranslation = 'incorrect',
+  OffensiveTranslation = 'offensive',
+  SuggestedTranslation = 'sugested'
 }
 
-export interface AddedWord {
+export interface Feedback {
   word: string;
   language: string;
   englishWord: string;
@@ -13,9 +12,8 @@ export interface AddedWord {
   nativeLanguage: string;
   transliteration: string;
   recording: Blob|null;
-}
-
-export interface Feedback extends AddedWord {
+  suggestedTranslation: string;
+  suggestedTransliteration: string;
   types: FeedbackType[];
   content: string;
 }

--- a/client/src/services/feedback.ts
+++ b/client/src/services/feedback.ts
@@ -1,9 +1,8 @@
 import { InjectionToken } from '@angular/core';
-import { Feedback, AddedWord } from './entities/feedback';
+import { Feedback} from './entities/feedback';
 
 export interface IFeedbackService {
   sendFeedback(feedback: Feedback): Promise<any>;
-  addWord(word: AddedWord): Promise<any>;
 }
 
 export const FEEDBACK_SERVICE = new InjectionToken<IFeedbackService>('Feedback service');

--- a/client/src/services/mock/feedback.ts
+++ b/client/src/services/mock/feedback.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { IFeedbackService } from '../feedback';
-import { Feedback, AddedWord } from '../entities/feedback';
+import { Feedback } from '../entities/feedback';
 import {getLogger} from 'util/logging';
 
 const logger = getLogger('MockFeedbackService');
@@ -11,15 +11,6 @@ export class MockFeedbackService implements IFeedbackService {
     return new Promise((resolve) => {
       setTimeout(() => {
         logger.log('Submitted feedback: ' + feedback.content);
-        resolve();
-      }, 2000);
-    });
-  }
-
-  public addWord(word: AddedWord): Promise<any> {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        logger.log('Added word: ' + word.englishWord);
         resolve();
       }, 2000);
     });

--- a/functions/cloudbuild.yaml
+++ b/functions/cloudbuild.yaml
@@ -9,13 +9,7 @@ steps:
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'
     dir: './functions'
-    args: [ 'functions', 'deploy', 'addSuggestions', '--runtime', 'nodejs12', '--project', '${PROJECT_ID}',
-            '--region=${_REGION}', '--trigger-http', '--allow-unauthenticated', '--set-env-vars',
-            'SUGGESTIONS_SPREADSHEET=${_SUGGESTIONS_SPREADSHEET},FEEDBACK_SPREADSHEET=${_FEEDBACK_SPREADSHEET},AUDIO_FOLDER_ID=${_AUDIO_FOLDER_ID}']
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: 'gcloud'
-    dir: './functions'
-    args: [ 'functions', 'deploy', 'addFeedback', '--runtime', 'nodejs12', '--project', '${PROJECT_ID}',
+    args: [ 'functions', 'deploy', 'create_feedback', '--runtime', 'nodejs12', '--project', '${PROJECT_ID}',
             '--region=${_REGION}', '--trigger-http', '--allow-unauthenticated', '--set-env-vars',
             'SUGGESTIONS_SPREADSHEET=${_SUGGESTIONS_SPREADSHEET},FEEDBACK_SPREADSHEET=${_FEEDBACK_SPREADSHEET},AUDIO_FOLDER_ID=${_AUDIO_FOLDER_ID}']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/functions/index.js
+++ b/functions/index.js
@@ -106,31 +106,7 @@ async function saveFeedback(spreadsheetId, sheetTitle, data) {
     });
 }
 
-exports.addSuggestions = async (req, res) => {
-    addSecurityHeaders(res);
-    return cors(req, res, async () => {
-        if (!validation.isTargetLanguage(req.body.native_language)) {
-            res.status(400).send("Invalid target language");
-            return;
-        } else if(!validation.isPrimaryLanguage(req.body.language)) {
-            res.status(400).send("Invalid primary language");
-            return;
-        }
-        await saveFeedback(process.env['SUGGESTIONS_SPREADSHEET'], req.body.native_language, [
-            req.body.language || '',
-            req.body.native_language || '',
-            req.body.english_word || '',
-            req.body.primary_word || '',
-            req.body.translation || '',
-            req.body.transliteration || '',
-            req.body.sound_link || '',
-            new Date()
-        ]);
-        res.status(200).send("Translation suggestions saved.");
-    });
-};
-
-exports.addFeedback = async (req, res) => {
+exports.create_feedback = async (req, res) => {
     addSecurityHeaders(res);
     return cors(req, res, async () => {
         if (!validation.isTargetLanguage(req.body.native_language)) {
@@ -147,6 +123,8 @@ exports.addFeedback = async (req, res) => {
             req.body.primary_word || '',
             req.body.translation || '',
             req.body.transliteration || '',
+            req.body.suggested_translation || '',
+            req.body.suggested_transliteration || '',
             req.body.sound_link || '',
             req.body.types ? req.body.types.join(', ') : '',
             req.body.content || '',


### PR DESCRIPTION
### Changes
- Use the same create-feedback endpoint for the feedback and user suggestion forms
- Always show the add word option
- Only display the current translation in the feedback form 
- Only display the recording element in the suggestion form
- Add suggested translation and transliteration fields to the request body 
- Mark these fields as optional on feedback forms 

### Screenshots

https://github.com/DotModus/woolaroo-language-learning-app/assets/128372789/55fbfd8e-8b1f-411c-b54d-0273256bb83c

